### PR TITLE
Spring Server와 동일 DB 사용을 위한 password 전처리 전략 구현

### DIFF
--- a/passport/local.js
+++ b/passport/local.js
@@ -16,8 +16,10 @@ module.exports = () => {
             if(!account) {
                 return done(null, false, { reason: '이메일 또는 비밀번호가 틀립니다.' });
             }
+            /// 비밀번호 전처리, ({bcrypt}제거)
+
             // 비밀번호 검증
-            const result = await bcrypt.compare(password, account.password);
+            const result = await bcrypt.compare(password, account.password.substr(8));/// account.password.substr(8) => {bcrypt} 제거
             // 비밀번호 검증에 실패한 경우
             if(!result) {
                 return done(null, false, { reason: '이메일 또는 비밀번호가 틀립니다.' });

--- a/routes/account.js
+++ b/routes/account.js
@@ -127,7 +127,7 @@ router.post('/join', async (req, res, next) => {
         const hashPW = await bcrypt.hash(req.body.password, 12);
         await Account.create({
             email: req.body.email,
-            password: hashPW,
+            password: `{bcrypt}${hashPW}`,
             name: req.body.name,
             birth: req.body.birth,
             student_id: req.body.student_id, /// studentId -> student_id
@@ -193,7 +193,7 @@ router.post('/settings/password', passport.authenticate("jwt", {session: false})
     try{
         // 기존 비밀번호 체크
         const isDBpw = await Account.findOne({where: { id: req.user.id}});
-        const isCheckBasic = await bcrypt.compare(req.body.currentPassword, isDBpw.password);
+        const isCheckBasic = await bcrypt.compare(req.body.currentPassword, isDBpw.password.substr(8));
 
         // 변경 불허!
         if(!isCheckBasic)
@@ -206,7 +206,7 @@ router.post('/settings/password', passport.authenticate("jwt", {session: false})
         // 모든 검증 통과, 변경 진행
         const newPassword = await bcrypt.hash(req.body.newPassword, 12);
         await Account.update({
-            password: newPassword,
+            password: `{bcrypt}${newPassword}`,
         }, { where: { id: req.user.id }});
 
         res.status(200).json({status : 200, errormessage: "비밀번호가 성공적으로 변경되었습니다."});


### PR DESCRIPTION
Spring Server와 동일한 DB를 사용하기 위해 두 서버간의 bcrypt처리 방식 차이에 대한 password string data의 전처리가 필요했다.
Sptring의 Bcrypt는 salt를 매 번 랜덤으로 사용, Node의 bcrypt 모듈은 직접 설정. 하지만 동일 인증 처리.

전처리 대상은 Node Server로 택.

prefix = {bcrypt}
총 3개의 경우에서 전처리 진행
1.  회원가입 : prefix를 해시된 password string에 붙인다.
2. 로그인 : DB에서 가져온 password string에서 prefix를 제거하여 사용한다.
3. 비밀번호 변경 : 2번과 1번의 전략을 모두 수행한다.

Test
동일 DataBase로 각 서버를 연결하여 로그인을 진행하여 테스트하였고, 모두 성공하였다.